### PR TITLE
Added delete to db/schema/event.js

### DIFF
--- a/app/db/schema/event.js
+++ b/app/db/schema/event.js
@@ -153,6 +153,15 @@ module.exports = (Sequelize, db) => {
         },
       },
     },
+
+    // starting in winter 2019, we want to soft-delete events by marking them as 'deleted'
+    // and then not serving them to the user, vs. deleting them from the database entirely.
+    deleted: {
+      type: Sequelize.BOOLEAN,
+      allowNull: false,
+      defaultValue: false,
+    },
+
   }, {
     // creating indices on frequently accessed fields improves efficiency
     indexes: [


### PR DESCRIPTION
Issue #20 seemed to ask only for creating the column in the database. I'm not super familiar with Sequelize but I tried adding a delete column to the event schema. I think what's required after this is:

- updating GET api/v1/event/past and GET api/v1/event/future and GET api/v1/event/:uuid? to only return events where deleted = false
- updating DELETE api/v1/event/:uuid? to set deleted = true
- don't change PATCH api/v1/event/:uuid?, but still allow people to manually use it to toggle deleted in case they want to undelete events
- migrate existing events to the new schema? I read a little bit about how to do that, I'm not familiar with how the production database works so I assume someone else could take care of this.

but I'm not sure, so please clarify if I'm wrong. I'm not very familiar with the codebase so it's possible I edited the completely wrong thing.